### PR TITLE
Update spawn.hpp dialog name

### DIFF
--- a/MPMissions/DayZ_Epoch_24.Napf/scripts/spawn/spawn.hpp
+++ b/MPMissions/DayZ_Epoch_24.Napf/scripts/spawn/spawn.hpp
@@ -1,4 +1,4 @@
-class spawn_dialog
+class e_spawn_dialog
 {
 	idd = -1;
 	movingenable = true;


### PR DESCRIPTION
Dialog was incorrectly named spawn_dialog but was called from spawn.sqf as e_spawn_dialog.
The Chernarus Overpoch uses e_spawn_dialog so I matched to that.

As discovered by Schweded http://opendayz.net/threads/support-sheeps-epoch-repack.14921/page-170#post-118297
